### PR TITLE
reworked setup.sh and added uninstall script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .taima/
 sync
 .sync_exclude
+.dollar_path

--- a/setup.sh
+++ b/setup.sh
@@ -8,10 +8,7 @@ if [[ ! -e $SHELL_CONF ]]; then
 fi
 
 if [[ -z $(grep "$EXPORT" "$SHELL_CONF") ]]; then 
-    echo "#############################################################*" >> $SHELL_CONF
-    echo "#                                                             #" >> $SHELL_CONF
-    echo "#  Taima hook, to allow for system wide taima program calls   #" >> $SHELL_CONF
-    echo "#                                                             #" >> $SHELL_CONF
-    echo "#############################################################*" >> $SHELL_CONF
 	echo $EXPORT >> $SHELL_CONF
 fi
+
+echo $EXPORT >> .dollar_path

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Shell routine to remove the PATH edit from the .bashrc. On next login
+# the path should be in a state prior to the taima application install.
+
+PATH_FILE="./.dollar_path"
+SHELL_CONF="$HOME/.bashrc"
+
+STRING=`cat $PATH_FILE`
+
+grep -v "$STRING" $SHELL_CONF > tmp
+
+cp ./tmp $SHELL_CONF
+rm ./tmp


### PR DESCRIPTION
This closes #7 

A uninstall shell script has been added. In order to simplify the  uninstall process, the [setup.sh](https://github.com/olekxander/taima/blob/main/setup.sh) has been edited aswell, so there is only one string inside the `.bashrc` to be removed. 
The `setup.sh` now creates a dotfile, that stores the exact string, that has been added to the `.bashrc`