### PR TITLE
fixed negative timedelta

### DIFF
--- a/src/_taima/gen/Time.py
+++ b/src/_taima/gen/Time.py
@@ -63,15 +63,16 @@ class Time(object):
     
     
     # stringify this instances start and end time and return both stored 
-    # in a tuple.
+    # in a tuple. A format must be supplied. Check out python docs for
+    # available formats.
     
-    def strf(self) -> tuple:
+    def strf(self, form: str) -> tuple:
         """
         Return start and end as string inside of a tuple, for this time
         instance.
         """
-        s: str = self.__start.strftime('%X')
-        e: str = self.__end.strftime('%X')
+        s: str = self.__start.strftime(form)
+        e: str = self.__end.strftime(form)
 
         return (s, e)
 

--- a/src/_taima/main/Session.py
+++ b/src/_taima/main/Session.py
@@ -32,7 +32,7 @@ class Session(object):
     #of the time object. After update of the dbo, the db gets updated too.
     def __update_dbo_and_db(self, time_obj: object):
         
-        times: tuple = time_obj.strf()
+        times: tuple = time_obj.strf('%c')
         type(self).db_obj.times.update({times[0]:times[1]})
         time_obj.calculate_total()
         type(self).db_obj.total += time_obj.total
@@ -61,7 +61,7 @@ class Session(object):
                     exec.submit(type(self).virt.nstruc.display_running_session)
                     exec.submit(type(self).virt.tassk.display_tb_unselected_active)
                     exec.submit(type(self).virt.taima.update_taima, type(self).db_obj, update_counter)                
-
+                                
                 curses.doupdate()
                 type(self).virt.nonblo.nodelay(1)
                 try:
@@ -80,6 +80,7 @@ class Session(object):
                         exec.submit(type(self).virt.taima.update_taima, type(self).db_obj, update_counter)
                         exec.submit(type(self).virt.nstruc.display_resume_session)
                         exec.submit(type(self).virt.tassk.display_tb_unselected_paused)
+                    
                     curses.doupdate()
                     curses.napms(1000)
                     type(self).virt.mesg.erase()

--- a/src/_taima/main/screen/comp/Taima.py
+++ b/src/_taima/main/screen/comp/Taima.py
@@ -187,21 +187,21 @@ class Taima(Pad):
         #draw all entries line by line
         for i in range(len(latest)):
             t = Time()
-            t.start = datetime.strptime(latest[i], '%X')
-            t.end = datetime.strptime(times[latest[i]], '%X')
+            t.start = datetime.strptime(latest[i], '%c')
+            t.end = datetime.strptime(times[latest[i]], '%c')
             t.calculate_total()
-            stamps = t.strf()
+            stamps = t.strf('%X')
             s = stamps[0]
             e = stamps[1]
 
             x = self._tm_unselected_x + 1
             self._pad.addstr(y, x, s)
             
-            x += len(latest[i]) + 1
+            x += len(s) + 1
             self._pad.addstr(y, x, ':')
             x += 2
             self._pad.addstr(y, x, e)
-            x += len(times[latest[i]])+2
+            x += len(e)+2
             s = str(t.total) + 'min'
             self._pad.addstr(y, x, s, colors[2][i])
             


### PR DESCRIPTION
Closes #1 

This fixes the negative timedelta, that was displayed on the Taima window, when the timer started before 0am and was paused after 0am. 
